### PR TITLE
Calc origin pose depth using offset from depth sensor, calc origin po…

### DIFF
--- a/auv_nav/process_data.py
+++ b/auv_nav/process_data.py
@@ -606,15 +606,23 @@ def process_data(filepath, force_overwite, start_datetime, finish_datetime):
     dead_reckoning_centre_list = copy.deepcopy(
         dead_reckoning_dvl_list)  # [:] #.copy()
     for i in range(len(dead_reckoning_centre_list)):
-        [x_offset, y_offset, z_offset] = body_to_inertial(
+        [x_offset, y_offset, a_offset] = body_to_inertial(
             dead_reckoning_centre_list[i].roll,
             dead_reckoning_centre_list[i].pitch,
             dead_reckoning_centre_list[i].yaw,
             vehicle.origin.surge - vehicle.dvl.surge,
             vehicle.origin.sway - vehicle.dvl.sway,
             vehicle.origin.heave - vehicle.dvl.heave)
+        [_, _, z_offset] = body_to_inertial(
+            dead_reckoning_centre_list[i].roll,
+            dead_reckoning_centre_list[i].pitch,
+            dead_reckoning_centre_list[i].yaw,
+            vehicle.origin.surge - vehicle.depth.surge,
+            vehicle.origin.sway - vehicle.depth.sway,
+            vehicle.origin.heave - vehicle.depth.heave)
         dead_reckoning_centre_list[i].northings += x_offset
         dead_reckoning_centre_list[i].eastings += y_offset
+        dead_reckoning_centre_list[i].altitude += a_offset
         dead_reckoning_centre_list[i].depth += z_offset
     # correct for altitude and depth offset too!
 

--- a/auv_nav/tools/interpolate.py
+++ b/auv_nav/tools/interpolate.py
@@ -267,12 +267,18 @@ def interpolate_sensor_list(sensor_list,
                 _centre_list[j].epoch_timestamp,
                 _centre_list[j-1].eastings,
                 _centre_list[j].eastings)-y_offset
+            sensor_list[i].altitude = interpolate(
+                sensor_list[i].epoch_timestamp,
+                _centre_list[j-1].epoch_timestamp,
+                _centre_list[j].epoch_timestamp,
+                _centre_list[j-1].altitude,
+                _centre_list[j].altitude) -z_offset
             sensor_list[i].depth = interpolate(
                 sensor_list[i].epoch_timestamp,
                 _centre_list[j-1].epoch_timestamp,
                 _centre_list[j].epoch_timestamp,
                 _centre_list[j-1].depth,
-                _centre_list[j].depth) # -z_offset
+                _centre_list[j].depth) -z_offset
             [sensor_list[i].latitude,
              sensor_list[i].longitude] = metres_to_latlon(
                 latitude_reference,


### PR DESCRIPTION
…se alt using offset from dvl, calc cam/chem sensor pose depth and alt using offset from origin pose.

Basically, currently the calculation of 'origin' poses (origin as in the point on the auv defined relative to sensors in the vehicle.yaml) is using offset of origin from dvl to calculate depth offset, this should be from depth sensor. Altitude is also not offsetted from dvl. (For BioCam these make little and no difference respectively as depth sensor is very closely located to dvl and dvl is our origin point on auv, but still, the calculations are missing and wrong.) Also currently depth and altitude of camera/chemical sensor poses are not adjusted for their depth offset from the origin point poses. This commit/branch fixes these issues.